### PR TITLE
feat: improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ myTableDetector.pollWithInterval(
     });
     // If doing many Airtable writes, be careful of 5rps rate limit
     return Promise.all(promises);
+  },
+  // errFunc is optional. If absent, the error will be logged to console and retried after interval.
+  // In that case, the recordId will not be logged.
+  async (err, recordId) => {
+    // recordId will be passed if the error is specific to a record
+    // (ex: the Meta field for a record isn't valid JSON because its been edited manually)
+    if (recordId) {
+      console.log(`Error for record ${recordId}:`);
+    }
+    console.log(err);
+    await sendAlertingWebhook(err);
   }
 );
 ```

--- a/src/ChangeDetector.test.js
+++ b/src/ChangeDetector.test.js
@@ -120,6 +120,32 @@ describe("Airtable Changes", () => {
         assert.equal(e.message, "AirtableError");
       }
     });
+
+    it("Should throw an RecordError if can't parse Meta field JSON", async () => {
+      const base = new Airtable.Base("airtable", "baseId");
+      const table = base.table("tableName");
+      sinon.stub(table, "select").returns({
+        all: () =>
+          Promise.resolve([
+            {
+              id: "someRecord",
+              fields: { Meta: "Not JSON" },
+              get(field) {
+                return this.fields[field];
+              }
+            }
+          ])
+      });
+
+      const changes = new ChangeDetector(table);
+
+      try {
+        await changes.pollOnce();
+      } catch (e) {
+        assert.equal(e.name, "RecordError");
+        assert.equal(e.message, "someRecord");
+      }
+    });
   }).timeout(10000);
 
   describe("#enrichRecords()", () => {

--- a/src/RecordError.js
+++ b/src/RecordError.js
@@ -1,0 +1,13 @@
+/**
+ * Thrown when an error rises from an individual record
+ * (such as issue parsing Meta field JSON).
+ */
+class RecordError extends Error {
+  constructor(recordId, cause) {
+    super(recordId);
+    this.cause = cause;
+    this.name = this.constructor.name;
+  }
+}
+
+module.exports = RecordError;


### PR DESCRIPTION
`pollOnce` will now throw a `RecordError` if an error is specific to a record (like invalid JSON in the meta field)

`pollWithInterval` has new optional param `errorFunc` to consume errors. In it's absence, behavior is the same.

Resolves #12 